### PR TITLE
Remove print statements that are python-2 specific.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ var sys_requirements = config.then(() => {
     details('`npm` not installed.  Please install npm.');
     process.exit(1);
 }).then(() => {
-    return run(`python -c 'import zmq; print "1"'`);mistune
+    return run(`python -c "import zmq"`);mistune
 }).then(stdout => {
     success('pyzmq installed');
 }).catch(err => {
@@ -119,7 +119,7 @@ var sys_requirements = config.then(() => {
 Before installing pyzmq, you may need to install python and zmq dev packages (\`python-dev\` and \`libzmq-dev\` on debian based distros).`);
     process.exit(1);
 }).then(() => {
-    return run(`python -c 'import pycurl; print "1"'`);mistune
+    return run(`python -c "import pycurl"`);mistune
 }).then(stdout => {
     success('pycurl installed');
 }).catch(err => {


### PR DESCRIPTION
I don't think they are needed at all, if there's an exception on import, that should be sufficient to produce an OS error code.  And that way, the code is simpler than trying to make the code python 2/3 compatible with escaped parens and all that :)

I tested it on my local install with the changes and it's fine, it detected at first a missing pycurl, and then worked once I had it.
